### PR TITLE
AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: generic
+dist: trusty
+
+script:
+  - URL=$(wget -q "https://github.com/ImageMagick/ImageMagick/releases" -O - | grep "gcc-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
+  - wget -c "https://github.com/$URL"
+  - chmod +x ./ImageMagick-*.AppImage
+  - ./ImageMagick-*.AppImage --appimage-extract
+  - cp polaroid-fy squashfs-root/usr/bin/
+  - chmod +x squashfs-root/usr/bin/polaroid-fy
+  - sed -i -e 's|usr/bin/magick|usr/bin/polaroid-fy|g' squashfs-root/AppRun
+  - cp polaroid-fy.desktop squashfs-root/
+  - rm squashfs-root/imagemagick.desktop
+  - wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+  - chmod +x ./appimagetool-x86_64.AppImage
+  - ./appimagetool-x86_64.AppImage -g squashfs-root/
+
+after_success:
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh polaroid-fy*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/polaroid-fy.desktop
+++ b/polaroid-fy.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=polaroid-fy
+Type=Application
+Exec=polaroid-fy
+Icon=imagemagick
+Comment=Create, edit, compose, or convert bitmap images
+Categories=Graphics;
+Terminal=true


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.